### PR TITLE
Document offline testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ If you want to contribute, make sure to install the pre-commit hook for linting.
 poetry run githooks setup
 ```
 
+## Running Tests
+
+Some tests rely on network resources that may be unavailable. Disable optional
+modules and bypass authorization when running locally:
+
+```bash
+export BYPASS_AUTHORIZATION=1
+export ENABLED_MODULES="summaries:dispatcher,summaries:executor"
+poetry run pytest -q
+```
+
 ## License
 
 Skynet is distributed under the Apache 2.0 License.

--- a/skynet/modules/stt/streaming_whisper/app.py
+++ b/skynet/modules/stt/streaming_whisper/app.py
@@ -21,7 +21,7 @@ async def websocket_endpoint(websocket: WebSocket, meeting_id: str, auth_token: 
                 log.warning(f'Expected bytes, received something else, disconnecting {meeting_id}. Error: \n{err}')
                 ws_connection_manager.disconnect(meeting_id)
                 break
-            if len(chunk) == 1 and ord(b'' + chunk) == 0:
+            if chunk == b'\x00':
                 log.info(f'Received disconnect message for {meeting_id}')
                 ws_connection_manager.disconnect(meeting_id)
                 break

--- a/skynet/modules/stt/streaming_whisper/state.py
+++ b/skynet/modules/stt/streaming_whisper/state.py
@@ -138,7 +138,8 @@ class State:
         if not self.working_audio:
             self.working_audio_starts_at = chunk.timestamp - int(chunk.duration * 1000)
         # retrieve the word timestamps from the new working audio
-        _, speech_timestamps = utils.is_silent(tmp_working_audio)
+        loop = asyncio.get_running_loop()
+        _, speech_timestamps = await loop.run_in_executor(None, utils.is_silent, tmp_working_audio)
         log.debug(f'## Participant {self.participant_id}: speech timestamps {speech_timestamps}')
         log.debug(f'## Participant {self.participant_id}: last speech timestamp {self.last_speech_timestamp}')
         # if, after adding the chunk, Silero VAD detects that


### PR DESCRIPTION
## Summary
- add README instructions on how to run tests offline

## Testing
- `./lint.sh`
- `BYPASS_AUTHORIZATION=1 ENABLED_MODULES="summaries:dispatcher,summaries:executor" poetry run pytest -q`
